### PR TITLE
Add distance metrics from PyDodo

### DIFF
--- a/airtools/distance.py
+++ b/airtools/distance.py
@@ -1,0 +1,207 @@
+import numpy as np
+from geopy import distance
+from scipy.spatial.distance import euclidean
+
+from . import utils
+
+# Default for major (equatorial) radius and flattening are 'WGS-84' values.
+major_semiaxis, minor_semiaxis, _FLATTENING = distance.ELLIPSOIDS["WGS-84"]
+_EARTH_RADIUS = major_semiaxis * 1000  # convert to metres
+
+
+def geodesic_distance(from_lat, from_lon, to_lat, to_lon, **kwargs):
+    """
+    Get geodesic distance between two (lat, lon) points in metres.
+    Parameters
+    ----------
+    from_lat : double
+        A double in the range ``[-90, 90]``. The `from` point's latitude.
+    from_lon : double
+        A double in the range ``[-180, 180)``. The `from` point's longitude.
+    to_lat : double
+        A double in the range ``[-90, 90]``. The `to` point's latitude.
+    to_lon : double
+        A double in the range ``[-180, 180)``. The `to` point's longitude.
+    **kwargs:
+        major_semiaxis : double, optional
+            The major (equatorial) radius of the ellipsoid. The default value is for WGS84.
+        flattening : double, optional
+            Ellipsoid flattening. The default value is for WGS84.
+    Returns
+    -------
+    geodesic_distance : double
+        The geodesic distance between two points.
+    Examples
+    --------
+    >>> >>> airtools.distance.geodesic_distance(from_lat = 51.5 , from_lon = 0.12, to_lat = 50.6, to_lon = -1.9)
+    """
+    major_semiaxis = (
+        _EARTH_RADIUS if "major_semiaxis" not in kwargs else kwargs["major_semiaxis"]
+    )
+    flattening = _FLATTENING if "flattening" not in kwargs else kwargs["flattening"]
+
+    utils._validate_latitude(from_lat)
+    utils._validate_longitude(from_lon)
+    utils._validate_latitude(to_lat)
+    utils._validate_longitude(to_lon)
+    utils._validate_is_positive(major_semiaxis, "major_semiaxis")
+    utils._validate_is_positive(flattening, "flattening")
+
+    # For GeoPy need to provide (major_semiaxis, minor_semiaxis, flattening) but
+    # only major_semiaxis & flattening vals are used --> ignore minor_semiaxis
+    return distance.geodesic(
+        (from_lat, from_lon),
+        (to_lat, to_lon),
+        ellipsoid=(major_semiaxis / 1000, minor_semiaxis, flattening),  # convert to km
+    ).meters
+
+
+def great_circle_distance(from_lat, from_lon, to_lat, to_lon, **kwargs):
+    """
+    Get great-circle distance between two (lat, lon) points in metres.
+    Parameters
+    ----------
+    from_lat : double
+        A double in the range ``[-90, 90]``. The `from` point's latitude.
+    from_lon : double
+        A double in the range ``[-180, 180)``. The `from` point's longitude.
+    to_lat : double
+        A double in the range ``[-90, 90]``. The `to` point's latitude.
+    to_lon : double
+        A double in the range ``[-180, 180)``. The `to` point's longitude.
+    **kwargs
+        radius : double, optional
+            The radius of the earth in metres. The default value is for WGS84.
+    Returns
+    -------
+    great_circle_distance : double
+        The great-circle distance between two points.
+    Examples
+    --------
+    >>> airtools.distance.great_circle_distance(from_lat = 51.5 , from_lon = 0.12, to_lat = 50.6, to_lon = -1.9)
+    """
+    radius = _EARTH_RADIUS if "radius" not in kwargs else kwargs["radius"]
+
+    utils._validate_latitude(from_lat)
+    utils._validate_longitude(from_lon)
+    utils._validate_latitude(to_lat)
+    utils._validate_longitude(to_lon)
+    utils._validate_is_positive(radius, "radius")
+
+    return distance.great_circle(
+        (from_lat, from_lon), (to_lat, to_lon), radius=radius / 1000  # convert to km
+    ).meters
+
+
+def vertical_distance(from_alt, to_alt, **kwargs):
+    """
+    Get vertical distance in metres between two altitudes (provided in metres).
+    Parameters
+    ----------
+    from_alt : double
+        A non-negatige double. The `from` point's altitude in metres.
+    to_alt : double
+        A non-negatige double. The `to` point's altitude in metres.
+    Returns
+    -------
+    vertical_distance : double
+        The verticle distance between two points.
+    Examples
+    --------
+    >>> airtools.distance.vertical_distance(from_alt = 200, to_alt = 350)
+    """
+    utils._validate_is_positive(from_alt, "altitude")
+    utils._validate_is_positive(to_alt, "altitude")
+
+    return abs(from_alt - to_alt)
+
+
+def _lla_to_ECEF(lat, lon, alt=0, radius=_EARTH_RADIUS, f=_FLATTENING):
+    """
+    Calculates ECEF coordinates of a point from lat, lon and alt.
+    Parameters
+    ----------
+    lat : double
+    lon : double
+    alt : int
+        Altitude in meters
+    radius : double, optional
+        Earth radius in metres (WGS84).
+    f : double, optional
+        Ellipsoidal flattening (WGS84).
+    Returns
+    -------
+    (double, double, double)
+        The (x, y, z) ECEF coordinates.
+    Notes
+    -----
+    https://en.wikipedia.org/wiki/ECEF
+    Examples
+    --------
+    >>> airtools.distance.lla_to_ECEF(lat = 51.5 , lon = 0.12, alt = 200)
+    """
+
+    lat_r = np.deg2rad(lat)
+    lon_r = np.deg2rad(lon)
+
+    e2 = 1 - (1 - f) * (1 - f)
+    N = radius / np.sqrt(1 - e2 * np.power(np.sin(lat_r), 2))
+
+    x = (N + alt) * np.cos(lat_r) * np.cos(lon_r)
+    y = (N + alt) * np.cos(lat_r) * np.sin(lon_r)
+    z = ((1 - e2) * N + alt) * np.sin(lat_r)
+
+    return (x, y, z)
+
+
+def euclidean_distance(from_lat, from_lon, from_alt, to_lat, to_lon, to_alt, **kwargs):
+    """
+    Get euclidean distance between two (lat, lon, alt) points in metres. The
+    points are converted to ECEF coordinates to calculate distance.
+    Parameters
+    ----------
+    from_lat : double
+        A double in the range ``[-90, 90]``. The `from` point's latitude.
+    from_lon : double
+        A double in the range ``[-180, 180)``. The `from` point's longitude.
+    from_alt : double
+        A non-negatige double. The from point's altitude in metres.
+    to_lat : double
+         A double in the range ``[-90, 90]``. The `to` point's latitude.
+    to_lon : double
+        A double in the range ``[-180, 180)``. The `to` point's longitude.
+    to_alt : double
+        A non-negatige double. The `to` point's altitude in metres.
+    **kwargs:
+        major_semiaxis : double, optional
+            The major (equatorial) radius of the ellipsoid. The default value is for WGS84.
+        flattening : double, optional
+            Ellipsoid flattening. The default value is for WGS84.
+    Returns
+    -------
+    euclidean_distance : double
+        The euclidean distance between two points.
+    Notes
+    -----
+    https://en.wikipedia.org/wiki/ECEF
+    Examples
+    --------
+    >>> airtools.distance.euclidean_distance(from_lat = 51.5 , from_lon = 0.12, from_alt = 200, to_lat = 50.6, to_lon = -1.9, to_alt = 350)
+    """
+    major_semiaxis = (
+        _EARTH_RADIUS if "major_semiaxis" not in kwargs else kwargs["major_semiaxis"]
+    )
+    flattening = _FLATTENING if "flattening" not in kwargs else kwargs["flattening"]
+
+    utils._validate_latitude(from_lat)
+    utils._validate_longitude(from_lon)
+    utils._validate_is_positive(from_alt, "altitude")
+    utils._validate_latitude(to_lat)
+    utils._validate_longitude(to_lon)
+    utils._validate_is_positive(to_alt, "altitude")
+    utils._validate_is_positive(major_semiaxis, " major_semiaxis")
+
+    from_ECEF = _lla_to_ECEF(from_lat, from_lon, from_alt, major_semiaxis, flattening)
+    to_ECEF = _lla_to_ECEF(to_lat, to_lon, to_alt, major_semiaxis, flattening)
+
+    return euclidean(from_ECEF, to_ECEF)

--- a/airtools/utils.py
+++ b/airtools/utils.py
@@ -1,0 +1,13 @@
+def _validate_latitude(lat):
+    """Assert latitude is in the range ``[-90, 90]``."""
+    assert abs(lat) <= 90, "Invalid value {} for latitude".format(lat)
+
+
+def _validate_longitude(lon):
+    """Assert longitude is in the range ``[-180, 180)``."""
+    assert -180 <= lon < 180, "Invalid value {} for longitude".format(lon)
+
+
+def _validate_is_positive(val, param_name):
+    """Assert val is non-negative."""
+    assert val >= 0, "Invalid value {} for {}".format(val, param_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import math
+import pytest
+
+import numpy as np
+
+from geopy import distance
+
+major_semiaxis, _, _ = distance.ELLIPSOIDS["WGS-84"]
+_EARTH_RADIUS = major_semiaxis * 1000
+
+
+def great_circle(from_lat, from_lon, to_lat, to_lon):
+    """Calculate great circle distance using the Haversine formula"""
+    dlat = from_lat - to_lat
+    dlon = from_lon - to_lon
+
+    a = (math.sin(np.deg2rad(dlat) / 2)) ** 2 + math.cos(
+        np.deg2rad(from_lat)
+    ) * math.cos(np.deg2rad(to_lat)) * (math.sin(np.deg2rad(dlon) / 2)) ** 2
+    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    expected = _EARTH_RADIUS * c
+    return expected
+
+
+@pytest.fixture
+def expected_great_circle():
+    return great_circle
+
+
+@pytest.fixture
+def earth_radius():
+    return _EARTH_RADIUS

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -1,0 +1,127 @@
+import pytest
+
+from airtools.distance import (
+    geodesic_distance,
+    great_circle_distance,
+    vertical_distance,
+    euclidean_distance,
+)
+
+
+def test_geodesic_distance():
+    from_lat = 51.507389
+    from_lon = 0.127806
+
+    to_lat = 50.6083
+    to_lon = -1.9608
+
+    result = geodesic_distance(from_lat, from_lon, to_lat, to_lon)
+
+    # Compare to the result calculated using ArcGIS (to within 1% error):
+    assert result == pytest.approx(1000 * 176.92, 0.01)
+
+    assert result == pytest.approx(
+        euclidean_distance(from_lat, from_lon, 0, to_lat, to_lon, 0), 0.01
+    )
+
+    result = geodesic_distance(0.123456789, 0.123456789, 0.123456789, 0.123456789)
+    assert result == 0
+
+
+@pytest.mark.parametrize(
+    "from_lat,from_lon,to_lat,to_lon",
+    [(51.507389, 0.127806, 50.6083, -1.9608), (0, 0, 0, 0), (89, 40, 89.1, 40)],
+)
+def test_great_circle_distance(
+    expected_great_circle, from_lat, from_lon, to_lat, to_lon
+):
+
+    result = great_circle_distance(from_lat, from_lon, to_lat, to_lon)
+
+    expected = expected_great_circle(from_lat, from_lon, to_lat, to_lon)
+
+    assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("from_alt,to_alt", [(0.123456789, 0.123456789), (150, 300)])
+def test_vertical_distance(from_alt, to_alt):
+
+    result = vertical_distance(from_alt, to_alt)
+
+    expected = abs(from_alt - to_alt)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "from_lat,from_lon,to_lat,to_lon,from_alt,to_alt,expected",
+    [
+        (45, 45, 45, 45, 1, 1, 0),
+        (21, 21, 21, 21, 1, 11, 10),
+        (51.507389, 0.127806, 50.6083, -1.9608, 50, 50, 1000 * 176.92),
+    ],
+)
+def test_euclidean_distance(
+    from_lat, from_lon, to_lat, to_lon, from_alt, to_alt, expected
+):
+    result = euclidean_distance(from_lat, from_lon, from_alt, to_lat, to_lon, to_alt)
+    assert result == pytest.approx(expected, 0.01)
+
+
+@pytest.mark.parametrize(
+    "from_lat,from_lon,to_lat,to_lon,from_alt,to_alt",
+    [
+        (-91, -180, 90, -180, -1, 1),
+        (-90, -180, 90, -180.5, -1, 1),
+        (-90, -180, 90, 180, 1, -1),
+    ],
+)
+def test_wrong_inputs(from_lat, from_lon, to_lat, to_lon, from_alt, to_alt):
+    with pytest.raises(AssertionError):
+        geodesic_distance(from_lat, from_lon, to_lat, to_lon)
+
+    with pytest.raises(AssertionError):
+        great_circle_distance(from_lat, from_lon, to_lat, to_lon)
+
+    with pytest.raises(AssertionError):
+        euclidean_distance(from_lat, from_lon, from_alt, to_lat, to_lon, to_alt)
+
+    with pytest.raises(AssertionError):
+        vertical_distance(from_alt, to_alt)
+
+
+@pytest.mark.parametrize(
+    "from_lat,from_lon,to_lat,to_lon",
+    [(51.507389, 0.127806, 50.6083, -1.9608), (0, 0, 0, 0), (89, 40, 89.1, 40)],
+)
+def test_optional_params(from_lat, from_lon, to_lat, to_lon):
+    """
+    Some distance functions take as optional params:
+    - radius/major_semiaxis (geodesic, great_circle, euclidean)
+    - flattening (geodesic)
+    Given all else is equal then:
+        geodesic_distance(..., flattening=0) == great_circle_distance(...)
+    """
+    r = 6378388
+    f = 0
+
+    result1 = geodesic_distance(
+        from_lat, from_lon, to_lat, to_lon, major_semiaxis=r, flattening=f
+    )
+    assert result1 == pytest.approx(
+        great_circle_distance(from_lat, from_lon, to_lat, to_lon, radius=r)
+    )
+
+    result2 = euclidean_distance(
+        from_lat, from_lon, 0, to_lat, to_lon, 0, major_semiaxis=r, flattening=f
+    )
+    assert result2 == pytest.approx(
+        geodesic_distance(
+            from_lat, from_lon, to_lat, to_lon, major_semiaxis=r, flattening=f
+        ),
+        0.01,
+    )
+
+    assert result2 == pytest.approx(
+        great_circle_distance(from_lat, from_lon, to_lat, to_lon, radius=r), 0.01
+    )


### PR DESCRIPTION
### Overview

The aim of this repo is to functions as a utils package for the entire package, handling tasks such as units conversions and distance metrics.

This PR moves distance metrics originally implemented in PyDodo. All functions take lat/lon coordinates as inputs. The measures include:
- great circle distance
- geodesic distance
- vertical distance
- euclidean (between 2 lat/lon/alt points converted to ECEF co-ordinates)

### Closes
<!-- List of issues this closes -->
Closes #3

### Checks
- [x] Have you added tests?
- [x] Have you added documentation?
- [x] Are all tests and linting passing?

### Information for reviewer
Key questions are around the structure/purpose of this repo:
- Do these functions belong here?
- Are there any metrics we are missing? 
- Should potential unit conversions happen before these functions are called or should the functions handle that somehow?